### PR TITLE
added --local and --testcmd options and cleaned up some other options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 2.3.5
+Version 2.4.0, 09.26.2024
 - Added `--local` option to generate a snakemake command that does not use a cluster, intended for testing purposes only.
 - Fixed the `--version`, `--quiet`, and `--options` flags to work with the config file.
 - Fixed spacing when string is longer than the pad.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 2.3.5
+- Added `--local` option to generate a snakemake command that does not use a cluster, intended for testing purposes only.
+- Fixed the `--version`, `--quiet`, and `--options` flags to work with the config file.
+- Fixed spacing when string is longer than the pad.
+- Added `--testcmd` to also print a direct PhyloAcc command at the end of the interface for testing purposes.
+
 Version 2.3.4, 09.24.2024
 - Reverted the element ID indexing in the interface from 1 to 0 to match the C++ code
 - Changed how the interface uses regex to read trees so it uses `r`aw strings

--- a/phyloacc-cfg-dev.yaml
+++ b/phyloacc-cfg-dev.yaml
@@ -264,6 +264,15 @@ cluster_time:
 # The time in hours to give each job. 
 # DEFAULT: 1.
 
+local_flag:
+# No cluster submission (--local)
+# Set this to instead generate a snakemake command to run the pipeline locally.
+# Recommended ONLY for testing
+# OPTIONS:
+# True: generate a snakemake command that runs locally.
+# False: generate a snakemake command and profile for a cluster.
+# DEFAULT: False
+
 ####################
 # Executable paths
 ####################
@@ -360,6 +369,15 @@ depcheck:
 # True: run the dependency check and exit.
 # False: do not run the dependency check and continue (normal run).
 # DEFAULT: False
+
+test_cmd_flag:
+# Generate test command (--testcmd)
+# Set this to also display a command that runs PhyloAcc directly on one of the batches
+# OPTIONS:
+# True: display the test command at the end of the program.
+# False: do not display the test command.
+# DEFAULT: False
+
 
 append_log_flag:
 # Append to log file (--append)

--- a/phyloacc-cfg-template.yaml
+++ b/phyloacc-cfg-template.yaml
@@ -260,6 +260,15 @@ cluster_time:
 # The time in hours to give each job. 
 # DEFAULT: 1.
 
+local_flag:
+# No cluster submission (--local)
+# Set this to instead generate a snakemake command to run the pipeline locally.
+# Recommended ONLY for testing
+# OPTIONS:
+# True: generate a snakemake command that runs locally.
+# False: generate a snakemake command and profile for a cluster.
+# DEFAULT: False
+
 ####################
 # Executable paths
 ####################
@@ -354,6 +363,15 @@ depcheck:
 # True: run the dependency check and exit.
 # False: do not run the dependency check and continue (normal run).
 # DEFAULT: False
+
+test_cmd_flag:
+# Generate test command (--testcmd)
+# Set this to also display a command that runs PhyloAcc directly on one of the batches
+# OPTIONS:
+# True: display the test command at the end of the program.
+# False: do not display the test command.
+# DEFAULT: False
+
 
 append_log_flag:
 # Append to log file (--append)

--- a/src/PhyloAcc-interface/phyloacc.py
+++ b/src/PhyloAcc-interface/phyloacc.py
@@ -30,40 +30,8 @@ if __name__ == '__main__':
 
     globs = params.init();
     # Get the global params as a dictionary.
-    
-    if any(v in sys.argv for v in ["--version", "-version", "--v", "-v"]):
-        print("\n# PhyloAcc version " + globs['version'] + " released on " + globs['releasedate-patch'])
-        sys.exit(0);
-    # The version option to simply print the version and exit.
-    # Need to get actual PhyloAcc version for this, and not just the interface version.
-
-    if "--options" in sys.argv:
-        opt_pad = 20;
-        print();
-        print("This is a list of other options for PhyloAcc that can be specified with -phyloacc:");
-        print(PC.spacedOut("OPTION", opt_pad) + "DEFAULT");
-        print("-" * 30);
-        for opt in globs['phyloacc-defaults']:
-            print(PC.spacedOut(opt, opt_pad) + globs['phyloacc-defaults'][opt]['default']);
-        print();
-        print("--options set: exiting...");
-        sys.exit();
-    
+  
     globs['script-dir'] = os.path.dirname(os.path.realpath(__file__));
-
-    if "--quiet" not in sys.argv:
-        print("\n" + " ".join(sys.argv) + "\n");
-        # Print the command used to call the program
-
-        print("#");
-        print("# " + "=" * 125);
-        print(PC.welcome());
-        if "-h" not in sys.argv:
-            print("    Bayesian rate analysis of conserved");
-            print("       non-coding genomic elements\n");
-        # A welcome banner.
-    else:
-        print("# Running phyloacc_interface in quiet mode...");
 
     globs = OP.optParse(globs);
     # Getting the input parameters from optParse.
@@ -180,13 +148,18 @@ if __name__ == '__main__':
 
     ####################
 
-    globs['smk-cmd'] = "snakemake -p -s " + os.path.abspath(globs['smk']);
-    globs['smk-cmd'] += " --configfile " + os.path.abspath(globs['smk-config']);
-    globs['smk-cmd'] += " --profile " + os.path.abspath(globs['profile-dir']);
-    #globs['smk-cmd'] += " --cluster-status " + os.path.abspath(globs['status-script']);
-    globs['smk-cmd'] += " --dryrun";
+    if globs['local']:
+        globs['smk-cmd'] = "snakemake -p -j " + str(globs['num-jobs']) + " -s " + os.path.abspath(globs['smk']);
+        globs['smk-cmd'] += " --configfile " + os.path.abspath(globs['smk-config']);
+        globs['smk-cmd'] += " --dryrun";
+    else:
+        globs['smk-cmd'] = "snakemake -p -s " + os.path.abspath(globs['smk']);
+        globs['smk-cmd'] += " --configfile " + os.path.abspath(globs['smk-config']);
+        globs['smk-cmd'] += " --profile " + os.path.abspath(globs['profile-dir']);
+        #globs['smk-cmd'] += " --cluster-status " + os.path.abspath(globs['status-script']);
+        globs['smk-cmd'] += " --dryrun";
     # The snakemake command to run PhyloAcc
-
+    
     ####################
 
     if globs['plot']:

--- a/src/PhyloAcc-interface/phyloacc_lib/batch.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/batch.py
@@ -176,7 +176,7 @@ def genJobFiles(globs):
                 cur_bed_file = os.path.join(globs['job-bed'], batch_num_str + "-" + model_type + ".bed");
                 with open(cur_bed_file, "w") as bedfile:
                     batch_aln_id = 0;
-                    ## NOTE: Right phyloacc requires element IDs to be integers starting from 0. I think this should be changed.
+                    ## NOTE: Right now phyloacc requires element IDs to be integers starting from 0. I think this should be changed.
                     for aln in batch_aln_list:
 
                         aln_len = globs['aln-stats'][aln]['length'];
@@ -250,6 +250,10 @@ def genJobFiles(globs):
                                                                             dollo_str=dollo_str
                                                                             ))
                 # Write the phyloacc config file for the current concatenated alignment
+
+                if batch_num == 1 and globs['test-cmd-flag']:
+                    globs['test-cmd'] = "PhyloAcc-" + model_type.upper() + " " + cur_cfg_file;
+                # Generate the test command if --testcmd is set.
             ## End batch block
         ## End batch loop
     ## End model partition loop

--- a/src/PhyloAcc-interface/phyloacc_lib/core.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/core.py
@@ -275,6 +275,8 @@ def printWrite(o_name, v, o_line1, o_line2="", pad=0):
 def spacedOut(string, totlen, sep=" "):
 # Properly adds spaces to the end of a message to make it a given length
     spaces = sep * (totlen - len(string));
+    if len(string) > totlen:
+        spaces += sep * 4;
     return string + spaces;
 
 #############################################################################
@@ -444,6 +446,20 @@ def report_step(globs, step, step_start_time, step_status, start=False, full_upd
 
 #############################################################################
 
+def printOptions(globs):
+    opt_pad = 20;
+    print();
+    print("This is a list of other options for PhyloAcc that can be specified with -phyloacc:");
+    print(spacedOut("OPTION", opt_pad) + "DEFAULT");
+    print("-" * 30);
+    for opt in globs['phyloacc-defaults']:
+        print(spacedOut(opt, opt_pad) + globs['phyloacc-defaults'][opt]['default']);
+    print();
+    print("--options set: exiting...");
+    sys.exit(0);
+
+#############################################################################
+
 def welcome():
 # Reads the ASCII art "Referee" text to be printed to the command line.
     return open(os.path.join(os.path.dirname(__file__), "pa-welcome.txt"), "r").read();
@@ -506,6 +522,10 @@ def endProg(globs, interface=True):
             printWrite(globs['logfilename'], 1, globs['smk-cmd'] + "\n\n");
             printWrite(globs['logfilename'], 1, "# Then, if everything looks right, remove --dryrun to execute");
             printWrite(globs['logfilename'], 1, "# You may also want to start your favorite terminal multiplexer (e.g. screen, tmux)");
+
+            if globs['test-cmd-flag']:
+                printWrite(globs['logfilename'], globs['log-v'], "#\n# Additionally, --testcmd was set, so here is an example command for one batch for testing:\n\n");
+                printWrite(globs['logfilename'], globs['log-v'], globs['test-cmd'] + "\n\n");
         else:
             printWrite(globs['logfilename'], globs['log-v'], "#\n# PhyloAcc summary files successfully generated");
             printWrite(globs['logfilename'], 1, "# This was a --summarize run, so no job files were created or overwritten");

--- a/src/PhyloAcc-interface/phyloacc_lib/info.yaml
+++ b/src/PhyloAcc-interface/phyloacc_lib/info.yaml
@@ -1,7 +1,7 @@
-version:	2.3.4
+version:	2.4.0
 releasedate-major:	April 1, 2022
-releasedate-minor:	March 26, 2024
-releasedate-patch:	September 24, 2024
+releasedate-minor:	September 26, 2024
+releasedate-patch:	September 26, 2024
 devs:	Zhirui Hu, Han Yan, Gregg Thomas, Tim Sackton, Scott Edwards, and Jun Liu
 doi:	https://doi.org/10.1093/molbev/msz049
 http:	https://phyloacc.github.io

--- a/src/PhyloAcc-interface/phyloacc_lib/params.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/params.py
@@ -173,6 +173,7 @@ def init():
         'num-nodes' : "1",
         'mem' : "4",
         'time' : "1",
+        'local': False,
         # Cluster options
 
         'aln-pool' : False,
@@ -218,10 +219,16 @@ def init():
         'smk-cmd' : '',
         # The final snakemake command to report
 
+        'test-cmd-flag' : False,
+        'test-cmd' : '',
+        # An example command to run a single batch
+
         'label-tree' : False,
         'info' : False,
         'dryrun' : False,
         'quiet' : False,
+        'options-flag': False,
+        'version-flag': False,
         # Other user options
 
         'aln-skip-chars' : ["-", "N"],


### PR DESCRIPTION
- Added `--local` option to generate a snakemake command that does not use a cluster, intended for testing purposes only.
- Fixed the `--version`, `--quiet`, and `--options` flags to work with the config file.
- Fixed spacing when string is longer than the pad.
- Added `--testcmd` to also print a direct PhyloAcc command at the end of the interface for testing purposes.