### PR TITLE
snakemake 8 for slurm

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,9 @@ In practice for many of these, using the command line option may be easier than 
 | `-j [INT]` | `num_jobs: [INT]` | The number of jobs (batches) to run in parallel. | 1 |
 | `-part "[STRING]"` | `cluster_part: [STRING]` | The SLURM partition or list of partitions (separated by commas) on which to run PhyloAcc jobs. | **REQUIRED** |
 | `-nodes [INT]` | `cluster_nodes: [INT]` | The number of nodes on the specified partition to submit jobs to. | 1 |
-| `-mem [INT]` | `cluster_mem: [INT]` | The max memory for each job in GB. | 4 |
-| `-time [INT]` | `cluster_time: [INT]` | The time in hours to give each job. | 1 |
+| `-mem [INT]` | `cluster_mem: [INT]` | The max memory for each job in MB. | 4 |
+| `-time [INT]` | `cluster_time: [INT]` | The time in minutes to give each job. | 1 |
+| `--local` | `local_flag: [true/false]` | Set this to generate a local snakemake workflow rather than one that will be submitted through SLURM with a profile. For testing purposes. | Optional |
 
 ### Executable path options
 
@@ -218,6 +219,7 @@ In practice for many of these, using the command line option may be easier than 
 
 | Command-line option | Config file key | Description | Default value |
 | ------------------- | --------------- |------------ | ------------- |
+| `--testcmd` | `testcmd_flag: [true/false]` | Also print out a command to run a single batch of PhyloAcc directly (without snakemake). For testing purposes. | Optional |
 | `--depcheck` | `depcheck: [true/false]` | Run this to check that all dependencies are installed at the provided path. No other options necessary. | Optional |
 | `--appendlog` | `append_log_flag: [true/false]` | Set this to keep the old log file even if `--overwrite` is specified. New log information will instead be appended to the previous log file. | Optional |
 | `--info` | `info_flag: [true/false]` | Print some meta information about the program and exit. No other options required. | Optional |

--- a/src/PhyloAcc-interface/phyloacc.py
+++ b/src/PhyloAcc-interface/phyloacc.py
@@ -149,7 +149,9 @@ if __name__ == '__main__':
     ####################
 
     if globs['local']:
-        globs['smk-cmd'] = "snakemake -p -j " + str(globs['num-jobs']) + " -s " + os.path.abspath(globs['smk']);
+        globs['smk-cmd'] = "snakemake -p --jobs " + str(globs['num-jobs']);
+        globs['smk-cmd'] += " --cores " + str(globs['procs-per-job'] * globs['num-jobs']);
+        globs['smk-cmd'] += " -s " + os.path.abspath(globs['smk']);
         globs['smk-cmd'] += " --configfile " + os.path.abspath(globs['smk-config']);
         globs['smk-cmd'] += " --dryrun";
     else:

--- a/src/PhyloAcc-interface/phyloacc_lib/opt_parse.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/opt_parse.py
@@ -705,14 +705,15 @@ def optParse(globs):
                     PC.errorOut("OP18", "At least one cluster partition must be specified with -part.", globs);
                 # Cluster partition option (required)
 
-                globs['num-nodes'] = getOpt(args.cluster_nodes, "cluster_nodes", "INTSTR", globs['num-nodes'], config, arg_flags, globs);
+                globs['num-nodes'] = str(getOpt(args.cluster_nodes, "cluster_nodes", int, globs['num-nodes'], config, arg_flags, globs));
                 # Cluster node option
 
-                globs['mem'] = getOpt(args.cluster_mem, "cluster_mem", "INTSTR", globs['mem'], config, arg_flags, globs);
+                globs['mem'] = getOpt(args.cluster_mem, "cluster_mem", int, globs['mem'], config, arg_flags, globs);
+                globs['mem'] = str(globs['mem'] * 1000);
                 # Cluster memory option
 
-                globs['time'] = getOpt(args.cluster_time, "cluster_time", "INTSTR", globs['time'], config, arg_flags, globs);
-                globs['time'] = globs['time'] + ":00:00";
+                globs['time'] = str(getOpt(args.cluster_time, "cluster_time", int, globs['time'], config, arg_flags, globs));
+                #globs['time'] = globs['time'] + ":00:00";
                 # Cluster time option
 
             ## Cluster options
@@ -860,8 +861,8 @@ def startProg(globs):
     else:
         PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Partition(s)", pad) + globs['partition']);
         PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Number of nodes", pad) + globs['num-nodes']);
-        PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Max mem per job (gb)", pad) + globs['mem']);
-        PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Time per job", pad) + globs['time']); 
+        PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Max mem per job (mb)", pad) + globs['mem']);
+        PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Time per (min)", pad) + globs['time']); 
     # Cluster options
     #######################
 

--- a/src/PhyloAcc-interface/phyloacc_lib/opt_parse.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/opt_parse.py
@@ -248,11 +248,11 @@ def optParse(globs):
     #parser.add_argument("-nodes", dest="cluster_nodes", help="The number of nodes on the specified partition to submit jobs to. Default: 1.", default=False);
     
     arg_flags.update(addArgument(parser, "-mem", "cluster_mem", int,
-        "The max memory for each job in GB. Default: 4."));
+        "The max memory for each job in MB. Default: 4."));
     #parser.add_argument("-mem", dest="cluster_mem", help="The max memory for each job in GB. Default: 4.", default=False);
     
     arg_flags.update(addArgument(parser, "-time", "cluster_time", int,
-        "The time in hours to give each job. Default: 1."));
+        "The time in minutes to give each job. Default: 1."));
     #parser.add_argument("-time", dest="cluster_time", help="The time in hours to give each job. Default: 1.", default=False);
 
     arg_flags.update(addArgument(parser, "--local", "local_flag", bool,

--- a/src/PhyloAcc-interface/phyloacc_lib/params.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/params.py
@@ -170,9 +170,9 @@ def init():
         # Number of jobs/procs for PhyloAcc to use
 
         'partition' : False,
-        'num-nodes' : "1",
-        'mem' : "4",
-        'time' : "1",
+        'num-nodes' : 1,
+        'mem' : 4,
+        'time' : 60,
         'local': False,
         # Cluster options
 

--- a/src/PhyloAcc-interface/phyloacc_lib/templates.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/templates.py
@@ -186,23 +186,13 @@ astral_directory: {astral}
 def snakemakeProfile():
     
     profile_template = """jobs: {num_jobs}
-cluster-sync:
-  mkdir -p {cluster_logdir}/{{rule}}/ &&
-  sbatch
-  --wait
-  --partition={{resources.partition}}
-  --nodes={{resources.nodes}}
-  --cpus-per-task={{resources.cpus}}
-  --job-name={{rule}}-{{wildcards}}
-  --mem={{resources.mem}}
-  --time={{resources.time}}
-  --output={cluster_logdir}/{{rule}}/{{rule}}-{{wildcards}}-%j.out
+executor: slurm
 default-resources:
-  - partition='{part}'
-  - nodes='{num_nodes}'
-  - mem='{mem}g'
-  - time='{time}'
-  - cpus={procs_per_job}
+  slurm_partition: '{part}'
+  nodes: {num_nodes}
+  mem_mb: {mem}
+  runtime: {time}
+  cpus_per_task: {procs_per_job}
 latency-wait: 45
 verbose: true
 """


### PR DESCRIPTION
Changed how the slurm profile is written to use snakemake 8. Now requires the snakemake slurm executor plugin.