### PR TITLE
added --softmask option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Version 2.4.5, 02.04.2026
+- Distinguish between lowercase and uppercase bases for QC, and add `--softmask` option to ignore them.
+- Updated build flags to use C++14 to satisfy Armadillo's compiler requirement.
+
+Version 2.4.4, 02.03.2026
+- Fixed a hang when reading config files containing very long single‑line parameters (e.g., large CONSERVE lists) by switching to safe line parsing.
+- Applied the same safer parsing to ID‑file reads in ST/GT variants.
+- No behavior changes for normal‑length configs.
+- Fixes --local warning displaying even when not in --local mode.
+
 Version 2.4.3, 03.25.2025
 - Fixed how tree labels are read in GT
 - Switched from bash script to Python functions to label ASTRAL tree internal nodes, which required adding the various hidden `-lt` options to `phyloacc.py`

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ $(info $$GSL_INCLUDE is [${GSL_INCLUDE}])
 $(info $$GSL_LIB is [${GSL_LIB}])
 # GSL paths with the conda environment prefix
 
-CFLAGS=-Wall -g -O2 -std=c++11
+CFLAGS=-Wall -g -O2 -std=c++14
 LDFLAGS=-lgsl -lm -lgslcblas -larmadillo -fopenmp
 # Options for the g++ commands
 

--- a/src/PhyloAcc-ST/main.cpp
+++ b/src/PhyloAcc-ST/main.cpp
@@ -198,7 +198,7 @@ void LoadParams(int argc, char* argv[])
             nprior_b = stod(param_line[1]);
         else if (param_line[0]=="ROPT")
             ropt = stoi(param_line[1]);
-        else if (param_line[0]=="CUB")
+        else if (param_line[0]=="CUB") 
             cub = stod(param_line[1]);
         else if (param_line[0]=="NLB")
             nlb = stod(param_line[1]);

--- a/src/PhyloAcc-interface/phyloacc_lib/opt_parse.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/opt_parse.py
@@ -121,7 +121,10 @@ def optParse(globs):
     arg_flags.update(addArgument(parser, "-d", "aln_dir", str,
         "A directory containing individual alignment files for each locus in FASTA format. One of -a/-b or -d is REQUIRED."));   
     #parser.add_argument("-d", dest="aln_dir", help="A directory containing individual alignment files for each locus. Expected as FASTA format for now. One of -a/-b or -d is REQUIRED.", default=False);
-    
+
+    arg_flags.update(addArgument(parser, "--softmask", "softmask", bool,
+        "Treat lowercase bases in alignments as masked (converted to N) before processing."));
+
     arg_flags.update(addArgument(parser, "-m", "mod_file", str,
         "A file with a background transition rate matrix and phylogenetic tree with branch lengths as output from phyloFit. REQUIRED."));
     #parser.add_argument("-m", dest="mod_file", help="A file with a background transition rate matrix and phylogenetic tree with branch lengths as output from PHAST. REQUIRED.", default=False);
@@ -506,6 +509,9 @@ def optParse(globs):
 
         globs['filter-alns'] = getOpt(args.filter_alns, "filter_alns", bool, globs['filter-alns'], config, arg_flags, globs);
         # Alignment filtering option
+
+        globs['softmask'] = getOpt(args.softmask, "softmask", bool, globs['softmask'], config, arg_flags, globs);
+        # Soft-masked bases option
 
         # Input files
         ####################

--- a/src/PhyloAcc-interface/phyloacc_lib/params.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/params.py
@@ -257,6 +257,7 @@ def init():
         'debug-aln' : False,
         'debug' : False,
         'nolog' : False,
+        'softmask' : False,
         # Internal stuff
     }
 

--- a/src/PhyloAcc-interface/phyloacc_lib/seq.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/seq.py
@@ -6,6 +6,7 @@
 import sys
 import os
 import gzip
+import re
 import phyloacc_lib.core as PC
 import multiprocessing as mp
 from itertools import groupby
@@ -47,6 +48,13 @@ def readFasta(filename, globs):
         seq = "".join(readstr(s) for s in fa_iter.__next__());
         # The current header should correspond to the current iterator in fa_iter. This gets all those
         # lines and combines them as a string.
+
+        if globs.get('softmask', False):
+            seq = re.sub(r"[acgt]", "N", seq);
+        # If softmasking is enabled, treat lowercase bases as masked
+
+        seq = seq.upper();
+        # Normalize case so lowercase bases are not distinct from uppercase
 
         #print(header, len(seq));
 


### PR DESCRIPTION
Default behavior treats lowercase bases as regular bases. `--softmask` ignores them.
Also update the compiler requirement for amradillo.