### PR TITLE
feat(interface): add --labelmod support and tighten BF plotting

### DIFF
--- a/src/PhyloAcc-interface/phyloacc.py
+++ b/src/PhyloAcc-interface/phyloacc.py
@@ -83,6 +83,14 @@ if __name__ == '__main__':
             #print(globs['labeled-tree']);
             #print();
             sys.exit(0);
+        elif globs['label-mod']:
+            PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Labelling tree and re-writing mod file:", 45) + globs['label-mod']);
+            desc_st = globs['st'].labelDesc();
+            mod_text = open(globs['mod-file']).read().replace(globs['tree-string'], desc_st);
+            with open(globs['label-mod'], 'w') as label_mod_stream:
+                label_mod_stream.write(mod_text);
+            globs['mod-file'] = globs['label-mod'];
+            globs['tree-string'], globs['st'] = TREEIO.readST(globs);      
         elif not globs['st'].has_label:
             PC.errorOut("MAIN2", "One or more internal nodes in your tree are unlabeled, which is required for PhyloAcc. Please label all internal nodes (maybe with the --labeltree option) and replace the tree in your .mod file with the labeled tree.", globs);
 

--- a/src/PhyloAcc-interface/phyloacc_lib/opt_parse.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/opt_parse.py
@@ -276,6 +276,9 @@ def optParse(globs):
         "Reads the tree from the input mod file (-m), labels the internal nodes, and exits."));        
     #parser.add_argument("--labeltree", dest="labeltree", help="Simply reads the tree from the input mod file (-m), labels the internal nodes, and exits.", action="store_true", default=False);
     
+    arg_flags.update(addArgument(parser, "--labelmod", "labelmod", bool,
+        "Reads the tree from the input mod file (-m), labels the internal nodes with ancestors, re-writes the mod file, and uses that for the analysis."));        
+
     arg_flags.update(addArgument(parser, "--overwrite", "overwrite_flag", bool,
         "Set this to overwrite existing files."));       
     #parser.add_argument("--overwrite", dest="overwrite_flag", help="Set this to overwrite existing files.", action="store_true", default=False);
@@ -439,6 +442,9 @@ def optParse(globs):
     #globs['label-tree'] = args.labeltree;
     globs['label-tree'] = getOpt(args.labeltree, "labeltree", bool, globs['label-tree'], config, arg_flags, globs);
     # Parse the --labeltree option
+
+    globs['label-mod'] = getOpt(args.labeltree, "labelmod", bool, globs['label-mod'], config, arg_flags, globs);
+    # Parse the --labeltree option    
 
     globs['test-cmd-flag'] = getOpt(args.test_cmd_flag, "test_cmd_flag", bool, False, config, arg_flags, globs);
     # Parse the --testcmd option
@@ -693,6 +699,10 @@ def optParse(globs):
                 logfile.close();
             # Prep the logfile to be overwritten
 
+            if globs['label-mod']:
+                base, ext = os.path.splitext(os.path.basename(globs['mod-file']));
+                globs['label-mod'] = os.path.join(globs['job-dir'], base + ".LABELED" + ext);
+
             ## Output files and directories
             ####################
 
@@ -823,6 +833,9 @@ def startProg(globs):
 
     PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Tree/rate file (mod file from phyloFit):", pad) + globs['mod-file']);
     #PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Tree read from mod file:", pad) + globs['tree-string']);
+
+    if globs['label-mod']:
+        PC.printWrite(globs['logfilename'], globs['log-v'], PC.spacedOut("# Labeling tree in mod file:", pad) + globs['label-mod']);
 
     if globs['debug-tree']:
         print("\n--debugtree SET. READING TREE AND EXITING.\n");

--- a/src/PhyloAcc-interface/phyloacc_lib/params.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/params.py
@@ -48,6 +48,9 @@ def init():
         'mod-file' : False,
         # Input rate and tree file from PHAST
 
+        'label-mod' : False,
+        # Option to label the mod file tree and use that for the analysis
+
         'seq-compression' : 'none',
         'bed-compression' : 'none',
         # The type of compression used for input sequence files

--- a/src/PhyloAcc-interface/phyloacc_lib/plot.py
+++ b/src/PhyloAcc-interface/phyloacc_lib/plot.py
@@ -352,12 +352,18 @@ def getBFs(globs):
     bf_lists = { bf_type : [] for bf_type in bf_types };
 
     for locus in globs['all-loci']:
+        locus_bfs = {};
         for bf_type in bf_types:
             bf = float(globs['locus-stats']['elem_lik'][locus][bf_type]);
             if math.isinf(bf):
                 print("WARNING: " + bf_type + " for locus " + locus + " is infinite. This locus may have failed to converge for this model. Excluding from plots...");
+                locus_bfs[bf_type] = "NA";
             else:
-                bf_lists[bf_type].append(bf);
+                locus_bfs[bf_type] = bf;
+        
+        if "NA" not in locus_bfs.values():
+            for bf_type in bf_types:
+                bf_lists[bf_type].append(locus_bfs[bf_type]);
 
     return tuple(bf_lists[bf_type] for bf_type in bf_types)
 


### PR DESCRIPTION
- Adds --labelmod option to automatically copy the mod file and label the tree within it to use with PhyloAcc.
- Updates interface parameter wiring related to --labelmod.
- Changes BF plotting input handling to skip loci with any infinite BF value (instead of partially including them).